### PR TITLE
Replace iron-component-page with api-doc-viewer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,15 +24,18 @@
     "wct.conf.js"
   ],
   "devDependencies": {
-    "elements-demo-resources": "#2.0-preview",
+    "elements-demo-resources": "2.0-preview",
     "iron-component-page": "#2.0-preview",
     "iron-demo-helpers": "#2.0-preview",
     "iron-test-helpers": "#2.0-preview",
     "web-component-tester": "^6.0.0-prerelease.7"
   },
   "dependencies": {
-    "polymer": "^2.0.0-rc.1",
+    "polymer": "^2.0.0",
     "vaadin-text-field": "#master",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.0.1"
+  },
+  "resolutions": {
+    "polymer": "^2.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "polymer": "^2.0.0",
-    "vaadin-text-field": "#master",
+    "vaadin-text-field": "^1.0.0-alpha3",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.0.1"
   },
   "resolutions": {

--- a/docs.json
+++ b/docs.json
@@ -1,73 +1,91 @@
 {
   "schema_version": "1.0.0",
-  "elements": [
+  "namespaces": [
     {
-      "description": "`<vaadin-button>` is a Polymer element for customized buttons.\n\n```html\n<vaadin-button>\n</vaadin-button>\n```\n\n### Styling\n\nThe following shadow DOM parts are exposed for styling:\n\nPart name | Description\n----------------|----------------\n`button` | The internal `<button>` element",
+      "name": "Vaadin",
+      "description": "",
       "summary": "",
-      "path": "vaadin-button.html",
-      "attributes": [],
-      "properties": [],
-      "methods": [
+      "sourceRange": {
+        "file": "vaadin-button.html",
+        "start": {
+          "line": 81,
+          "column": 7
+        },
+        "end": {
+          "line": 81,
+          "column": 43
+        }
+      },
+      "elements": [
         {
-          "name": "ready",
-          "description": "",
-          "privacy": "protected",
+          "description": "`<vaadin-button>` is a Polymer element for customized buttons.\n\n```html\n<vaadin-button>\n</vaadin-button>\n```\n\n### Styling\n\nThe following shadow DOM parts are exposed for styling:\n\nPart name | Description\n----------------|----------------\n`button` | The internal `<button>` element",
+          "summary": "",
+          "path": "vaadin-button.html",
+          "attributes": [],
+          "properties": [],
+          "methods": [
+            {
+              "name": "ready",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 56,
+                  "column": 8
+                },
+                "end": {
+                  "line": 65,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": []
+            }
+          ],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "demos": [],
+          "slots": [
+            {
+              "description": "",
+              "name": "",
+              "range": {
+                "file": "vaadin-button.html",
+                "start": {
+                  "line": 29,
+                  "column": 6
+                },
+                "end": {
+                  "line": 29,
+                  "column": 19
+                }
+              }
+            }
+          ],
+          "events": [],
+          "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 54,
+              "line": 55,
               "column": 6
             },
             "end": {
-              "line": 63,
+              "line": 74,
               "column": 7
             }
           },
-          "metadata": {},
-          "params": []
+          "privacy": "public",
+          "tagname": "vaadin-button",
+          "classname": "Vaadin.ButtonElement",
+          "mixins": [
+            "Vaadin.ControlStateMixin",
+            "Vaadin.ThemableMixin"
+          ],
+          "superclass": "HTMLElement"
         }
-      ],
-      "styling": {
-        "cssVariables": [],
-        "selectors": []
-      },
-      "demos": [],
-      "slots": [
-        {
-          "description": "",
-          "name": "",
-          "range": {
-            "file": "vaadin-button.html",
-            "start": {
-              "line": 29,
-              "column": 6
-            },
-            "end": {
-              "line": 29,
-              "column": 19
-            }
-          }
-        }
-      ],
-      "events": [],
-      "metadata": {},
-      "sourceRange": {
-        "start": {
-          "line": 53,
-          "column": 4
-        },
-        "end": {
-          "line": 72,
-          "column": 5
-        }
-      },
-      "privacy": "public",
-      "tagname": "vaadin-button",
-      "classname": "VaadinButtonElement",
-      "mixins": [
-        "Vaadin.ControlStateMixin",
-        "Vaadin.ThemableMixin"
-      ],
-      "superclass": "HTMLElement"
+      ]
     }
   ]
 }

--- a/docs.json
+++ b/docs.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "1.0.0",
+  "elements": [
+    {
+      "description": "`<vaadin-button>` is a Polymer element for customized buttons.\n\n```html\n<vaadin-button>\n</vaadin-button>\n```\n\n### Styling\n\nThe following shadow DOM parts are exposed for styling:\n\nPart name | Description\n----------------|----------------\n`button` | The internal `<button>` element",
+      "summary": "",
+      "path": "vaadin-button.html",
+      "attributes": [],
+      "properties": [],
+      "methods": [
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 6
+            },
+            "end": {
+              "line": 63,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "demos": [],
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "vaadin-button.html",
+            "start": {
+              "line": 29,
+              "column": 6
+            },
+            "end": {
+              "line": 29,
+              "column": 19
+            }
+          }
+        }
+      ],
+      "events": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 53,
+          "column": 4
+        },
+        "end": {
+          "line": 72,
+          "column": 5
+        }
+      },
+      "privacy": "public",
+      "tagname": "vaadin-button",
+      "classname": "VaadinButtonElement",
+      "mixins": [
+        "Vaadin.ControlStateMixin",
+        "Vaadin.ThemableMixin"
+      ],
+      "superclass": "HTMLElement"
+    }
+  ]
+}

--- a/docs.json
+++ b/docs.json
@@ -9,11 +9,11 @@
         "file": "vaadin-button.html",
         "start": {
           "line": 81,
-          "column": 7
+          "column": 6
         },
         "end": {
           "line": 81,
-          "column": 43
+          "column": 42
         }
       },
       "elements": [
@@ -21,8 +21,133 @@
           "description": "`<vaadin-button>` is a Polymer element for customized buttons.\n\n```html\n<vaadin-button>\n</vaadin-button>\n```\n\n### Styling\n\nThe following shadow DOM parts are exposed for styling:\n\nPart name | Description\n----------------|----------------\n`button` | The internal `<button>` element",
           "summary": "",
           "path": "vaadin-button.html",
-          "attributes": [],
-          "properties": [],
+          "attributes": [
+            {
+              "name": "autofocus",
+              "description": "Specify that this control should have input focus when the page loads.",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 44,
+                  "column": 8
+                },
+                "end": {
+                  "line": 46,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "focused",
+              "description": "If true, the element currently has focus.",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 51,
+                  "column": 8
+                },
+                "end": {
+                  "line": 57,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "disabled",
+              "description": "If true, the user cannot interact with this element.",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 62,
+                  "column": 8
+                },
+                "end": {
+                  "line": 66,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            }
+          ],
+          "properties": [
+            {
+              "name": "autofocus",
+              "type": "boolean",
+              "description": "Specify that this control should have input focus when the page loads.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 44,
+                  "column": 8
+                },
+                "end": {
+                  "line": 46,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "focused",
+              "type": "boolean",
+              "description": "If true, the element currently has focus.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 51,
+                  "column": 8
+                },
+                "end": {
+                  "line": 57,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "notify": true,
+                  "observer": "\"_focusedChanged\"",
+                  "readOnly": true
+                }
+              },
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "disabled",
+              "type": "boolean",
+              "description": "If true, the user cannot interact with this element.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 62,
+                  "column": 8
+                },
+                "end": {
+                  "line": 66,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "observer": "\"_disabledChanged\""
+                }
+              },
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            }
+          ],
           "methods": [
             {
               "name": "ready",
@@ -40,6 +165,197 @@
               },
               "metadata": {},
               "params": []
+            },
+            {
+              "name": "connectedCallback",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 96,
+                  "column": 4
+                },
+                "end": {
+                  "line": 101,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "disconnectedCallback",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 103,
+                  "column": 4
+                },
+                "end": {
+                  "line": 108,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_focusedChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 110,
+                  "column": 4
+                },
+                "end": {
+                  "line": 118,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "focused"
+                }
+              ],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_bodyKeydownListener",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 120,
+                  "column": 4
+                },
+                "end": {
+                  "line": 122,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_bodyKeyupListener",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 124,
+                  "column": 4
+                },
+                "end": {
+                  "line": 126,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_focus",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 137,
+                  "column": 4
+                },
+                "end": {
+                  "line": 145,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "blur",
+              "description": "Native bluring in the host element does nothing because it does not have the focus.\nIn chrome it works, but not in FF.",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 152,
+                  "column": 4
+                },
+                "end": {
+                  "line": 154,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_disabledChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 156,
+                  "column": 4
+                },
+                "end": {
+                  "line": 165,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "disabled"
+                }
+              ],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
+            },
+            {
+              "name": "_tabindexChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-text-field/vaadin-control-state-mixin.html",
+                "start": {
+                  "line": 167,
+                  "column": 4
+                },
+                "end": {
+                  "line": 179,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "tabindex"
+                }
+              ],
+              "inheritedFrom": "Vaadin.ControlStateMixin"
             }
           ],
           "styling": {

--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="../webcomponentsjs/webcomponents-lite.js"></script>
-    <link rel="import" href="../iron-component-page/iron-component-page.html">
+    <link rel="import" href="../elements-demo-resources/api-doc-viewer.html">
   </head>
   <body>
-    <iron-component-page src="vaadin-button.html"></iron-component-page>
+    <api-doc-viewer url="docs.json" element-class-name="Vaadin.ButtonElement"></api-doc-viewer>
   </body>
 </html>

--- a/vaadin-button.html
+++ b/vaadin-button.html
@@ -31,47 +31,56 @@ This program is available under Apache License Version 2.0, available at https:/
     </button>
   </template>
   <script>
-    /**
-     * `<vaadin-button>` is a Polymer element for customized buttons.
-     *
-     * ```html
-     * <vaadin-button>
-     * </vaadin-button>
-     * ```
-     *
-     * ### Styling
-     *
-     * The following shadow DOM parts are exposed for styling:
-     *
-     * Part name | Description
-     * ----------------|----------------
-     * `button` | The internal `<button>` element
-     *
-     * @mixes Vaadin.ControlStateMixin
-     * @mixes Vaadin.ThemableMixin
-     * @demo demo/index.html
-     */
-    class VaadinButtonElement extends Vaadin.ControlStateMixin(Vaadin.ThemableMixin(Polymer.Element)) {
-      ready() {
-        super.ready();
+    (function() {
+      /**
+      * `<vaadin-button>` is a Polymer element for customized buttons.
+      *
+      * ```html
+      * <vaadin-button>
+      * </vaadin-button>
+      * ```
+      *
+      * ### Styling
+      *
+      * The following shadow DOM parts are exposed for styling:
+      *
+      * Part name | Description
+      * ----------------|----------------
+      * `button` | The internal `<button>` element
+      *
+      * @memberof Vaadin
+      * @mixes Vaadin.ControlStateMixin
+      * @mixes Vaadin.ThemableMixin
+      * @demo demo/index.html
+      */
+      class ButtonElement extends Vaadin.ControlStateMixin(Vaadin.ThemableMixin(Polymer.Element)) {
+        ready() {
+          super.ready();
 
-        // Leaving default role in the native button, makes navigation announcement
-        // being different when using focus navigation (tab) versus using normal
-        // navigation (arrows). The first way announces the label on a button
-        // since the focus is moved programmatically, and the second on a group.
-        this.setAttribute('role', 'button');
-        this.$.button.setAttribute('role', 'presentation');
+          // Leaving default role in the native button, makes navigation announcement
+          // being different when using focus navigation (tab) versus using normal
+          // navigation (arrows). The first way announces the label on a button
+          // since the focus is moved programmatically, and the second on a group.
+          this.setAttribute('role', 'button');
+          this.$.button.setAttribute('role', 'presentation');
+        }
+
+        static get is() {
+          return 'vaadin-button';
+        }
+
+        get focusElement() {
+          return this.$.button;
+        }
       }
 
-      static get is() {
-        return 'vaadin-button';
-      }
+      customElements.define(ButtonElement.is, ButtonElement);
 
-      get focusElement() {
-        return this.$.button;
-      }
-    }
-
-    customElements.define(VaadinButtonElement.is, VaadinButtonElement);
+      /**
+       * @namespace Vaadin
+       */
+      window.Vaadin = window.Vaadin || {};
+      Vaadin.ButtonElement = ButtonElement;
+    })();
   </script>
 </dom-module>

--- a/vaadin-button.html
+++ b/vaadin-button.html
@@ -5,23 +5,6 @@ This program is available under Apache License Version 2.0, available at https:/
 -->
 
 <!--
-`<vaadin-button>` is a Polymer element for customized buttons.
-
-```html
-<vaadin-button>
-</vaadin-button>
-```
-
-### Styling
-
-The following shadow DOM parts are exposed for styling:
-
-Part name | Description
-----------------|----------------
-`button` | The internal `<button>` element
-
-@element vaadin-button
-@demo demo/index.html
 -->
 
 <link rel="import" href="../polymer/polymer-element.html">
@@ -48,6 +31,26 @@ Part name | Description
     </button>
   </template>
   <script>
+    /**
+     * `<vaadin-button>` is a Polymer element for customized buttons.
+     *
+     * ```html
+     * <vaadin-button>
+     * </vaadin-button>
+     * ```
+     *
+     * ### Styling
+     *
+     * The following shadow DOM parts are exposed for styling:
+     *
+     * Part name | Description
+     * ----------------|----------------
+     * `button` | The internal `<button>` element
+     *
+     * @mixes Vaadin.ControlStateMixin
+     * @mixes Vaadin.ThemableMixin
+     * @demo demo/index.html
+     */
     class VaadinButtonElement extends Vaadin.ControlStateMixin(Vaadin.ThemableMixin(Polymer.Element)) {
       ready() {
         super.ready();

--- a/vaadin-button.html
+++ b/vaadin-button.html
@@ -33,26 +33,26 @@ This program is available under Apache License Version 2.0, available at https:/
   <script>
     (function() {
       /**
-      * `<vaadin-button>` is a Polymer element for customized buttons.
-      *
-      * ```html
-      * <vaadin-button>
-      * </vaadin-button>
-      * ```
-      *
-      * ### Styling
-      *
-      * The following shadow DOM parts are exposed for styling:
-      *
-      * Part name | Description
-      * ----------------|----------------
-      * `button` | The internal `<button>` element
-      *
-      * @memberof Vaadin
-      * @mixes Vaadin.ControlStateMixin
-      * @mixes Vaadin.ThemableMixin
-      * @demo demo/index.html
-      */
+       * `<vaadin-button>` is a Polymer element for customized buttons.
+       *
+       * ```html
+       * <vaadin-button>
+       * </vaadin-button>
+       * ```
+       *
+       * ### Styling
+       *
+       * The following shadow DOM parts are exposed for styling:
+       *
+       * Part name | Description
+       * ----------------|----------------
+       * `button` | The internal `<button>` element
+       *
+       * @memberof Vaadin
+       * @mixes Vaadin.ControlStateMixin
+       * @mixes Vaadin.ThemableMixin
+       * @demo demo/index.html
+       */
       class ButtonElement extends Vaadin.ControlStateMixin(Vaadin.ThemableMixin(Polymer.Element)) {
         ready() {
           super.ready();


### PR DESCRIPTION
Connects to https://github.com/vaadin/components-team-tasks/issues/239
Depends on https://github.com/vaadin/vaadin-text-field/pull/61 being merged first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-button/13)
<!-- Reviewable:end -->
