### PR TITLE
Add styles for native button from normalize.css. Closes #28

### DIFF
--- a/vaadin-button.html
+++ b/vaadin-button.html
@@ -24,6 +24,24 @@ This program is available under Apache License Version 2.0, available at https:/
       [part="button"] {
         width: 100%;
         height: 100%;
+        margin: 0; /* (normalize.css) Remove the margin in Firefox and Safari. */
+        overflow: visible; /* (normalize.css) Show the overflow in IE. */
+        text-transform: none; /* (normalize.css) Remove the inheritance of text transform in Edge, Firefox, and IE. */
+      }
+
+      /**
+       * (normalize.css) Remove the inner border and padding in Firefox.
+       */
+      [part="button"]::-moz-focus-inner {
+        border-style: none;
+        padding: 0;
+      }
+
+      /**
+       * (normalize.css) Restore the focus styles unset by the previous rule.
+       */
+      [part="button"]:-moz-focusring {
+        outline: 1px dotted ButtonText;
       }
     </style>
     <button id="button" type="button" part="button">


### PR DESCRIPTION
Not sure if this should be here, maybe `vaadin-themes` repo could provide a special theme with styles grabbed from `normalize.css`? If so, close this PR and I'll send another one to implement it there. But placing such styles together with element itself looks more clear for end-users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-button/29)
<!-- Reviewable:end -->
