### PR TITLE
Revert Mozilla specific styles

### DIFF
--- a/vaadin-button.html
+++ b/vaadin-button.html
@@ -26,22 +26,6 @@ This program is available under Apache License Version 2.0, available at https:/
         height: 100%;
         margin: 0; /* (normalize.css) Remove the margin in Firefox and Safari. */
         overflow: visible; /* (normalize.css) Show the overflow in IE. */
-        text-transform: none; /* (normalize.css) Remove the inheritance of text transform in Edge, Firefox, and IE. */
-      }
-
-      /**
-       * (normalize.css) Remove the inner border and padding in Firefox.
-       */
-      [part="button"]::-moz-focus-inner {
-        border-style: none;
-        padding: 0;
-      }
-
-      /**
-       * (normalize.css) Restore the focus styles unset by the previous rule.
-       */
-      [part="button"]:-moz-focusring {
-        outline: 1px dotted ButtonText;
       }
     </style>
     <button id="button" type="button" part="button">


### PR DESCRIPTION
`:-moz-focusring` only supported in older Firefox (4.x), so `:-moz-focusring` rule not needed either. Remove `text-transform: none`. Fixes #28

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-button/31)
<!-- Reviewable:end -->
