### PR TITLE
Create the vaadin-button-default-theme

### DIFF
--- a/vaadin-button.html
+++ b/vaadin-button.html
@@ -9,6 +9,14 @@ This program is available under Apache License Version 2.0, available at https:/
 <link rel="import" href="../vaadin-themable-mixin/vaadin-themable-mixin.html">
 <link rel="import" href="../vaadin-control-state-mixin/vaadin-control-state-mixin.html">
 
+<dom-module id="vaadin-button-default-theme">
+  <template>
+    <style>
+      /* TODO: Implement default theme. */
+    </style>
+  </template>
+</dom-module>
+
 <dom-module id="vaadin-button">
   <template>
     <style>


### PR DESCRIPTION
Create the `vaadin-button-default-theme` to avoid the following warning:

<img width="918" alt="screen shot 2017-08-08 at 11 29 30" src="https://user-images.githubusercontent.com/1007051/29065593-e440bcbe-7c2c-11e7-85e8-8917b7884110.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-button/37)
<!-- Reviewable:end -->
