### PR TITLE
Hotfix: active state

### DIFF
--- a/test/vaadin-button_test.html
+++ b/test/vaadin-button_test.html
@@ -18,12 +18,12 @@
 
   <script>
     describe('vaadin-button', () => {
-      var down = node => {
-        node.dispatchEvent(new CustomEvent('down'));
+      var mousedown = node => {
+        node.dispatchEvent(new CustomEvent('mousedown'));
       };
 
-      var up = node => {
-        node.dispatchEvent(new CustomEvent('up'));
+      var mouseup = node => {
+        node.dispatchEvent(new CustomEvent('mouseup'));
       };
 
       var vaadinButton, nativeButton;
@@ -64,15 +64,15 @@
       });
 
       it('should have active attribute on down', () => {
-        down(vaadinButton);
+        mousedown(vaadinButton);
 
         expect(vaadinButton.hasAttribute('active')).to.be.true;
       });
 
       it('should not have active attribute after up', () => {
-        down(vaadinButton);
+        mousedown(vaadinButton);
 
-        up(vaadinButton);
+        mouseup(vaadinButton);
 
         expect(vaadinButton.hasAttribute('active')).to.be.false;
       });
@@ -107,7 +107,7 @@
 
       it('should not have active attribute when disabled', () => {
         vaadinButton.disabled = true;
-        down(vaadinButton);
+        mousedown(vaadinButton);
         MockInteractions.keyDownOn(vaadinButton, 13);
         MockInteractions.keyDownOn(vaadinButton, 32);
 

--- a/vaadin-button.html
+++ b/vaadin-button.html
@@ -91,8 +91,10 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _addActiveListeners() {
-          this._addEventListenerToNode(this, 'down', () => !this.disabled && this.setAttribute('active', ''));
-          this._addEventListenerToNode(this, 'up', () => this.removeAttribute('active'));
+          this._addEventListenerToNode(this, 'mousedown', () => !this.disabled && this.setAttribute('active', ''));
+          this._addEventListenerToNode(this, 'touchstart', () => !this.disabled && this.setAttribute('active', ''));
+          this._addEventListenerToNode(this, 'mouseup', () => this.removeAttribute('active'));
+          this._addEventListenerToNode(this, 'touchend', () => !this.disabled && this.removeAttribute('active'));
           this.addEventListener('keydown', e => !this.disabled && [13, 32].indexOf(e.keyCode) >= 0 && this.setAttribute('active', ''));
           this.addEventListener('keyup', () => this.removeAttribute('active'));
         }


### PR DESCRIPTION
Fixes #46 

Change `down` and `up` events to `mousedown` ( + `touchend`) and `mouseup` ( + `touchstart`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-button/47)
<!-- Reviewable:end -->
