### PR TITLE
Polymer.GestureEventListeners

### DIFF
--- a/vaadin-button.html
+++ b/vaadin-button.html
@@ -5,6 +5,7 @@ This program is available under Apache License Version 2.0, available at https:/
 -->
 
 <link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../polymer/lib/mixins/gesture-event-listeners.html">
 <link rel="import" href="../vaadin-themable-mixin/vaadin-themable-mixin.html">
 <link rel="import" href="../vaadin-control-state-mixin/vaadin-control-state-mixin.html">
 
@@ -70,9 +71,10 @@ This program is available under Apache License Version 2.0, available at https:/
        * @memberof Vaadin
        * @mixes Vaadin.ControlStateMixin
        * @mixes Vaadin.ThemableMixin
+       * @mixes Polymer.GestureEventListeners
        * @demo demo/index.html
        */
-      class ButtonElement extends Vaadin.ControlStateMixin(Vaadin.ThemableMixin(Polymer.Element)) {
+      class ButtonElement extends Vaadin.ControlStateMixin(Vaadin.ThemableMixin(Polymer.GestureEventListeners(Polymer.Element))) {
         static get is() {
           return 'vaadin-button';
         }

--- a/vaadin-button.html
+++ b/vaadin-button.html
@@ -93,8 +93,8 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _addActiveListeners() {
-          this._addEventListenerToNode(this, 'down', () => !this.disabled && this.setAttribute('active', ''));
-          this._addEventListenerToNode(this, 'up', () => this.removeAttribute('active'));
+          Polymer.Gestures.addListener(this, 'down', () => !this.disabled && this.setAttribute('active', ''));
+          Polymer.Gestures.addListener(this, 'up', () => this.removeAttribute('active'));
           this.addEventListener('keydown', e => !this.disabled && [13, 32].indexOf(e.keyCode) >= 0 && this.setAttribute('active', ''));
           this.addEventListener('keyup', () => this.removeAttribute('active'));
         }


### PR DESCRIPTION
Fixes #46 

Add back the import of Polymer.GestureEventListeners as it required for `down` and `up` event listeners for changing `active` state

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-button/50)
<!-- Reviewable:end -->
