### PR TITLE
Fix host vertical align

### DIFF
--- a/theme/valo/vaadin-button.html
+++ b/theme/valo/vaadin-button.html
@@ -54,7 +54,6 @@
       :host {
         font-family: var(--valo-font-family);
         font-size: var(--valo-font-size-m);
-        line-height: var(--valo-line-height-xs);
         font-weight: 500;
         color: var(--valo-primary-text-color);
         background-color: var(--valo-contrast-5pct);
@@ -63,6 +62,13 @@
         -webkit-tap-highlight-color: transparent;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
+      }
+
+      /* Set only for the internal parts so we don’t affect the host vertical alignment */
+      [part="label"],
+      [part="prefix"],
+      [part="suffix"] {
+        line-height: var(--valo-line-height-xs);
       }
     </style>
   </template>


### PR DESCRIPTION
The line height of the parent scope is the one that sets the vertical alignment context, so in order to play nice with other content, we should not adjust it for the button host element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-button/59)
<!-- Reviewable:end -->
