### PR TITLE
Remove active state when disconnected from the DOM

### DIFF
--- a/src/vaadin-button.html
+++ b/src/vaadin-button.html
@@ -156,6 +156,19 @@ This program is available under Apache License Version 2.0, available at https:/
           this._addActiveListeners();
         }
 
+        /**
+         * @protected
+         */
+        disconnectedCallback() {
+          super.disconnectedCallback();
+
+          // `active` state is preserved when the element is disconnected between keydown and keyup events.
+          // reproducible in `<vaadin-date-picker>` when closing on `Cancel` or `Today` click.
+          if (this.hasAttribute('active')) {
+            this.removeAttribute('active');
+          }
+        }
+
         _addActiveListeners() {
           Polymer.Gestures.addListener(this, 'down', () => !this.disabled && this.setAttribute('active', ''));
           Polymer.Gestures.addListener(this, 'up', () => this.removeAttribute('active'));

--- a/test/vaadin-button_test.html
+++ b/test/vaadin-button_test.html
@@ -115,6 +115,12 @@
         expect(vaadinButton.hasAttribute('active')).to.be.false;
       });
 
+      it('should not have active attribute when disconnected from the DOM', () => {
+        MockInteractions.keyDownOn(vaadinButton, 32);
+        vaadinButton.parentNode.removeChild(vaadinButton);
+        window.ShadyDOM && window.ShadyDOM.flush();
+        expect(vaadinButton.hasAttribute('active')).to.be.false;
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
Connected to vaadin/vaadin-date-picker#505

Note: there was a similar issue with `vaadin-item` fixed previously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-button/65)
<!-- Reviewable:end -->
