### PR TITLE
Remove IE11 workaround, update theme to use height

### DIFF
--- a/demo/button-basic-demos.html
+++ b/demo/button-basic-demos.html
@@ -37,12 +37,6 @@
           <iron-icon icon="lumo:arrow-right" slot="suffix"></iron-icon>
           Next
         </vaadin-button>
-
-        <vaadin-button>
-          <iron-icon icon="lumo:user"></iron-icon>
-          <br>
-          Profile
-        </vaadin-button>
       </template>
     </vaadin-demo-snippet>
 

--- a/src/vaadin-button.html
+++ b/src/vaadin-button.html
@@ -57,16 +57,6 @@ This program is available under Apache License Version 2.0, available at https:/
         text-overflow: ellipsis;
       }
 
-      /* When there is no text label, icons are misaligned on IE11 */
-      ::-ms-backdrop,
-      [part="label"]::before {
-        content: "\2003";
-        display: inline-block;
-        width: 0;
-        /* Compensate the space the character reserves */
-        margin-right: -0.275em;
-      }
-
       #button {
         position: absolute;
         top: 0;

--- a/src/vaadin-button.html
+++ b/src/vaadin-button.html
@@ -15,7 +15,7 @@ This program is available under Apache License Version 2.0, available at https:/
     <style>
       :host {
         display: inline-block;
-        position: relative !important;
+        position: relative;
         outline: none;
         white-space: nowrap;
       }

--- a/src/vaadin-button.html
+++ b/src/vaadin-button.html
@@ -15,7 +15,6 @@ This program is available under Apache License Version 2.0, available at https:/
     <style>
       :host {
         display: inline-block;
-        align-items: center;
         position: relative !important;
         outline: none;
         white-space: nowrap;

--- a/theme/lumo/vaadin-button.html
+++ b/theme/lumo/vaadin-button.html
@@ -254,7 +254,7 @@
 <dom-module id="lumo-button-icons">
   <template>
     <style>
-      :host ::slotted(iron-icon) {
+      [part] ::slotted(iron-icon) {
         display: inline-block;
         width: var(--lumo-icon-size-m);
         height: var(--lumo-icon-size-m);

--- a/theme/lumo/vaadin-button.html
+++ b/theme/lumo/vaadin-button.html
@@ -25,7 +25,7 @@
       :host {
         --lumo-button-size: var(--lumo-size-m);
         min-width: calc(var(--lumo-button-size) * 2);
-        min-height: var(--lumo-button-size);
+        height: var(--lumo-button-size);
         padding: 0 calc(var(--lumo-button-size) / 3 + var(--lumo-border-radius) / 2);
         margin: var(--lumo-space-xs) 0;
         box-sizing: border-box;
@@ -173,7 +173,7 @@
       :host([theme~="tertiary-inline"]) {
         margin: 0;
         min-width: 0;
-        min-height: 0;
+        height: auto;
         padding: 0;
         line-height: inherit;
         font-size: inherit;


### PR DESCRIPTION
Fixes #66 

The issue related to the HTML minification was caused by the IE-specific workaround, introduced because of the `min-height` flex bug (yes, this rabbit hole goes really deep).

So after some discussion with @jouni we decided to break this ugly chain of hacks and workarounds by just using fixed height.

Since this is a breaking change anyways, we are inclined to remove the `!important` on the host element at the same time, getting rid of that evil stuff as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-button/69)
<!-- Reviewable:end -->
