### PR TITLE
Set visible overflow for tertiary-inline label

### DIFF
--- a/theme/lumo/vaadin-button-styles.html
+++ b/theme/lumo/vaadin-button-styles.html
@@ -151,6 +151,7 @@
 
       :host([theme~="tertiary-inline"]) [part="label"] {
         padding: 0;
+        overflow: visible;
         line-height: inherit;
       }
 


### PR DESCRIPTION
See https://github.com/vaadin/vaadin-button/issues/79#issuecomment-377670959.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-button/80)
<!-- Reviewable:end -->
