### PR TITLE
Use bare module specifiers in the P3 conversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
       npm install -g yarn magi-cli polymer-cli@next &&
       (cd .. && git clone --depth 1 -b vaadin-components git://github.com/web-padawan/polymer-modulizer.git && cd polymer-modulizer && npm link) &&
       rm -rf node_modules &&
-      magi p3-convert --out . &&
+      magi p3-convert --out . --import-style=name &&
       yarn install --flat &&
       if [[ "$TRAVIS_EVENT_TYPE" = "pull_request" ]]; then
         xvfb-run -s '-screen 0 1024x768x24' polymer test --module-resolution=node --npm -l chrome;

--- a/test/index.html
+++ b/test/index.html
@@ -11,8 +11,6 @@
 
 <body>
   <script>
-    WCT._config.environmentScripts.push('webcomponentsjs/webcomponents-lite.js');
-
     WCT.loadSuites(
       window.VaadinButtonSuites
         .reduce(function(suites, suite) {

--- a/test/vaadin-button_test.html
+++ b/test/vaadin-button_test.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <title>vaadin-button tests</title>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../iron-test-helpers/mock-interactions.js"></script>
-  <link rel="import" href="../../polymer/polymer.html">
+  <link rel="import" href="../../iron-test-helpers/mock-interactions.html">
+  <link rel="import" href="../../polymer/lib/utils/flattened-nodes-observer.html">
   <link rel="import" href="../vaadin-button.html">
 </head>
 
@@ -35,7 +35,7 @@
       });
 
       it('should define button label using light DOM', () => {
-        var children = Polymer.dom(label).getEffectiveChildNodes();
+        const children = Polymer.FlattenedNodesObserver.getFlattenedNodes(label);
         expect(children[1].textContent).to.be.equal('Vaadin ');
         expect(children[2].outerHTML).to.be.equal('<i>Button</i>');
       });

--- a/test/vaadin-button_test.html
+++ b/test/vaadin-button_test.html
@@ -4,7 +4,9 @@
   <meta charset="UTF-8">
   <title>vaadin-button tests</title>
   <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../iron-test-helpers/mock-interactions.html">
+  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../../polymer/lib/utils/flattened-nodes-observer.html">
   <link rel="import" href="../vaadin-button.html">
 </head>

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -18,7 +18,9 @@ module.exports = {
       'macOS 10.12/iphone@11.2',
       'macOS 10.12/ipad@11.2',
       'Windows 10/chrome@65',
-      'macOS 10.12/safari@11.0'
+      'macOS 10.12/safari@11.0',
+      'Windows 10/firefox@59',
+      'Windows 10/microsoftedge@16'
     ];
 
     var cronPlatforms = [


### PR DESCRIPTION
Connected to vaadin/components-team-tasks#332

Also did some cleanup to eliminate the single legacy `Polymer.dom` usage.

The `mock-interactions` change is needed because of the fact that `mock-interactions.js` still use the `Polymer.Base.async` and the HTML file imports the needed dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-button/82)
<!-- Reviewable:end -->
