### PR TITLE
Fix duplicate id attribute in demo

### DIFF
--- a/demo/button-basic-demos.html
+++ b/demo/button-basic-demos.html
@@ -30,7 +30,7 @@
 
     <h3>Using an Icon</h3>
     <p>Follow these tips when using icons in buttons. Check out the <a href="#button-accessibility-demos">Accessible Icon Button</a> example as well.</p>
-    <vaadin-demo-snippet id='button-basic-demos-disabled'>
+    <vaadin-demo-snippet id='button-basic-demos-icon'>
       <template preserve-content>
         <!-- Use the "prefix/suffix" slots to place an icon before/after the text label.
              This ensure proper alignment of the icon. -->


### PR DESCRIPTION
The file had two `<vaadin-demo-snippet id='button-basic-demos-disabled'>` with the same `id` under different headers ("Disabled" and "Using an Icon")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-button/105)
<!-- Reviewable:end -->
