### PR TITLE
Add tabindex -1 to native button

### DIFF
--- a/src/vaadin-button.html
+++ b/src/vaadin-button.html
@@ -143,8 +143,10 @@ This program is available under Apache License Version 2.0, available at https:/
           // being different when using focus navigation (tab) versus using normal
           // navigation (arrows). The first way announces the label on a button
           // since the focus is moved programmatically, and the second on a group.
+          // Button with role="presentation" is required to not be in tab order.
           this.setAttribute('role', 'button');
           this.$.button.setAttribute('role', 'presentation');
+          this.$.button.setAttribute('tabindex', '-1');
 
           this._addActiveListeners();
         }


### PR DESCRIPTION
Fixes #96 

https://dequeuniversity.com/rules/axe/2.2/button-name?application=lighthouse
```
Ensure that each <button> element and elements with role="button" have one of the following characteristics:

role="presentation" or role="none" (ARIA 1.1) and is not in tab order (tabindex="-1").
```