### PR TITLE
refactor: use attributeChangedCallback for aria-label

### DIFF
--- a/src/vaadin-button.html
+++ b/src/vaadin-button.html
@@ -77,7 +77,7 @@ This program is available under Apache License Version 2.0, available at https:/
         <slot name="suffix"></slot>
       </div>
     </div>
-    <button id="button" type="button"></button>
+    <button id="button" type="button" aria-label$="[[_ariaLabel]]"></button>
   </template>
   <script>
     (function() {
@@ -144,11 +144,14 @@ This program is available under Apache License Version 2.0, available at https:/
              * default) means that the `aria-label` attribute is not present at
              * all.
              */
-            ariaLabel: {
-              type: String,
-              observer: '_ariaLabelChanged'
+            _ariaLabel: {
+              type: String
             }
           };
+        }
+
+        static get observedAttributes() {
+          return super.observedAttributes.concat(['aria-label']);
         }
 
         ready() {
@@ -162,7 +165,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.$.button.setAttribute('role', 'presentation');
 
           this._addActiveListeners();
-          this._ariaLabelChanged(this.ariaLabel);
+          this._updateAriaLabel(this.getAttribute('aria-label'));
         }
 
         /**
@@ -178,6 +181,16 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /**
+         * @protected
+         */
+        attributeChangedCallback(attr, oldVal, newVal) {
+          super.attributeChangedCallback(attr, oldVal, newVal);
+          if (attr === 'aria-label') {
+            this._updateAriaLabel(newVal);
+          }
+        }
+
         _addActiveListeners() {
           Polymer.Gestures.addListener(this, 'down', () => !this.disabled && this.setAttribute('active', ''));
           Polymer.Gestures.addListener(this, 'up', () => this.removeAttribute('active'));
@@ -186,12 +199,8 @@ This program is available under Apache License Version 2.0, available at https:/
           this.addEventListener('blur', () => this.removeAttribute('active'));
         }
 
-        _ariaLabelChanged(ariaLabel) {
-          if (ariaLabel !== undefined && ariaLabel !== null) {
-            this.$.button.setAttribute('aria-label', ariaLabel);
-          } else {
-            this.$.button.setAttribute('aria-label', this.innerText);
-          }
+        _updateAriaLabel(ariaLabel) {
+          this._ariaLabel = ariaLabel !== undefined && ariaLabel !== null ? ariaLabel : this.innerText;
         }
 
         /**

--- a/test/vaadin-button_test.html
+++ b/test/vaadin-button_test.html
@@ -130,7 +130,7 @@
         expect(vaadinButton.hasAttribute('active')).to.be.false;
       });
 
-      it('should set buttom text to native button aria-label', () => {
+      it('should set button text to native button aria-label', () => {
         expect(nativeButton.hasAttribute('aria-label')).to.be.true;
         // Remove extra line breaks
         expect(nativeButton.getAttribute('aria-label').replace(/(\r\n|\n|\r)/gm, ''))
@@ -138,9 +138,18 @@
       });
 
       it('should set button aria-label to native button aria-label', () => {
-        vaadinButton.ariaLabel = 'accessible';
+        vaadinButton.setAttribute('aria-label', 'accessible');
         expect(nativeButton.hasAttribute('aria-label')).to.be.true;
-        expect(nativeButton.getAttribute('aria-label')).to.be.eql(vaadinButton.ariaLabel);
+        expect(nativeButton.getAttribute('aria-label')).to.be.eql('accessible');
+      });
+
+      it('should set button aria-label when adding dynamically', () => {
+        const button = document.createElement('vaadin-button');
+        button.setAttribute('aria-label', '1');
+        button.textContent = '2';
+        document.body.appendChild(button);
+        expect(button.shadowRoot.querySelector('button').getAttribute('aria-label')).to.equal('1');
+        document.body.removeChild(button);
       });
     });
   </script>


### PR DESCRIPTION
Fixes #124 

Note: property is still needed as the `attributeChangedCallback` might be invoked for the first time before the shadow DOM is constructed. Added the test for it creating button dynamically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-button/125)
<!-- Reviewable:end -->
