### PR TITLE
Add CSS variables for lumo background and text colors

### DIFF
--- a/theme/lumo/vaadin-button-styles.html
+++ b/theme/lumo/vaadin-button-styles.html
@@ -19,8 +19,8 @@
         font-family: var(--lumo-font-family);
         font-size: var(--lumo-font-size-m);
         font-weight: 500;
-        color: var(--lumo-primary-text-color);
-        background-color: var(--lumo-contrast-5pct);
+        color: var(--_lumo-button-color, var(--lumo-primary-text-color));
+        background-color: var(--_lumo-button-background-color, var(--lumo-contrast-5pct));
         border-radius: var(--lumo-border-radius);
         cursor: default;
         -webkit-tap-highlight-color: transparent;
@@ -156,8 +156,8 @@
       }
 
       :host([theme~="primary"]) {
-        background-color: var(--lumo-primary-color);
-        color: var(--lumo-primary-contrast-color);
+        background-color: var(--_lumo-button-primary-background-color, var(--lumo-primary-color));
+        color: var(--_lumo-button-primary-color, var(--lumo-primary-contrast-color));
         font-weight: 600;
         min-width: calc(var(--lumo-button-size) * 2.5);
       }


### PR DESCRIPTION
For default and primary themes, to enable theming inside a notification.
Connects to https://github.com/vaadin/vaadin-notification/issues/104

Related branch for notification, which depends on this feature: https://github.com/vaadin/vaadin-notification/compare/button-color-variables

